### PR TITLE
Use concurrent collections for storage

### DIFF
--- a/avoinspector/src/main/java/app/avo/inspector/AvoBatcher.java
+++ b/avoinspector/src/main/java/app/avo/inspector/AvoBatcher.java
@@ -141,7 +141,7 @@ class AvoBatcher {
                 batchFlushAttemptMillis = System.currentTimeMillis();
 
                 final List<Map<String, Object>> sendingEvents = events;
-                events = new ArrayList<>();
+                events = Collections.synchronizedList(new ArrayList<Map<String, Object>>());
 
                 networkCallsHandler.reportInspectorWithBatchBody(sendingEvents,
                         new AvoNetworkCallsHandler.Callback() {

--- a/avoinspector/src/main/java/app/avo/inspector/AvoDeduplicator.java
+++ b/avoinspector/src/main/java/app/avo/inspector/AvoDeduplicator.java
@@ -2,19 +2,19 @@ package app.avo.inspector;
 
 import androidx.annotation.VisibleForTesting;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static app.avo.inspector.Util.mapsEqual;
 
 class AvoDeduplicator {
 
-	private static Map<Long, String> avoFunctionsEvents = new HashMap<>();
-	private static Map<Long, String> manualEvents = new HashMap<>();
+	private static ConcurrentHashMap<Long, String> avoFunctionsEvents = new ConcurrentHashMap<>();
+	private static ConcurrentHashMap<Long, String> manualEvents = new ConcurrentHashMap<>();
 
-	private static Map<String, Map<String, ?>> avoFunctionsEventsParams = new HashMap<>();
-	private static Map<String, Map<String, ?>> manualEventsParams = new HashMap<>();
+	private static ConcurrentHashMap<String, Map<String, ?>> avoFunctionsEventsParams = new ConcurrentHashMap<>();
+	private static ConcurrentHashMap<String, Map<String, ?>> manualEventsParams = new ConcurrentHashMap<>();
 
 	private static AvoSchemaExtractor avoSchemaExtractor = new AvoSchemaExtractor();
 
@@ -132,7 +132,7 @@ class AvoDeduplicator {
 		long now = System.currentTimeMillis();
 		long msToConsiderOld = 300;
 
-		for(Iterator<Map.Entry<Long, String>> it = avoFunctionsEvents.entrySet().iterator(); it.hasNext(); ) {
+		for(Iterator<Map.Entry<Long, String>> it = avoFunctionsEvents.entrySet().iterator(); it.hasNext();) {
 			Map.Entry<Long, String> entry = it.next();
 			Long timestamp = entry.getKey();
 			String eventName = entry.getValue();
@@ -142,7 +142,7 @@ class AvoDeduplicator {
 			}
 		}
 
-		for(Iterator<Map.Entry<Long, String>> it = manualEvents.entrySet().iterator(); it.hasNext(); ) {
+		for(Iterator<Map.Entry<Long, String>> it = manualEvents.entrySet().iterator(); it.hasNext();) {
 			Map.Entry<Long, String> entry = it.next();
 			Long timestamp = entry.getKey();
 			String eventName = entry.getValue();


### PR DESCRIPTION
Based on the following crash reports:

Fatal Exception: java.util.ConcurrentModificationException
       at java.util.HashMap$HashIterator.remove(HashMap.java:1467)
       at app.avo.inspector.AvoDeduplicator.clearOldEvents(AvoDeduplicator.java:204)
       at app.avo.inspector.AvoDeduplicator.shouldRegisterEvent(AvoDeduplicator.java:23)
       at app.avo.inspector.AvoInspector.trackSchemaFromEvent(AvoInspector.java:176)

Fatal Exception: java.util.ConcurrentModificationException
       at java.util.HashMap$HashIterator.nextNode(HashMap.java:1441)
       at java.util.HashMap$EntryIterator.next(HashMap.java:1475)
       at java.util.HashMap$EntryIterator.next(HashMap.java:1473)
       at app.avo.inspector.AvoDeduplicator.clearOldEvents(AvoDeduplicator.java:200)
       at app.avo.inspector.AvoDeduplicator.shouldRegisterEvent(AvoDeduplicator.java:23)
       at app.avo.inspector.AvoInspector.trackSchemaFromEvent(AvoInspector.java:176)

Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=10; index=10
       at java.util.ArrayList.add(ArrayList.java:468)
       at app.avo.inspector.AvoBatcher.batchTrackEventSchema(AvoBatcher.java:110)
       at app.avo.inspector.AvoInspector.trackSchemaInternal(AvoInspector.java:297)
       at app.avo.inspector.AvoInspector.trackSchemaFromEvent(AvoInspector.java:182)