### PR TITLE
Fix possible division by zero and add kotlin list tests

### DIFF
--- a/avoinspector/src/main/java/app/avo/inspector/AvoBatcher.java
+++ b/avoinspector/src/main/java/app/avo/inspector/AvoBatcher.java
@@ -117,7 +117,7 @@ class AvoBatcher {
         long now = System.currentTimeMillis();
         long millisSinceLastFlushAttempt = now - this.batchFlushAttemptMillis;
 
-        if (batchSize % AvoBatcher.batchSize == 0 || millisSinceLastFlushAttempt >=
+        if (AvoBatcher.batchSize == 0 || batchSize % AvoBatcher.batchSize == 0 || millisSinceLastFlushAttempt >=
                 TimeUnit.SECONDS.toMillis(batchFlushSeconds)) {
             postAllAvailableEvents(false);
         }

--- a/avoinspectorexample/build.gradle
+++ b/avoinspectorexample/build.gradle
@@ -38,6 +38,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -53,6 +57,9 @@ dependencies {
     //releaseImplementation 'com.github.avohq.android-avo-inspector:prod:2.0.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.mockito:mockito-core:2.28.2"
 }
 repositories {
     mavenCentral()

--- a/avoinspectorexample/src/test/java/app/avo/inspector/KotlinListsTest.kt
+++ b/avoinspectorexample/src/test/java/app/avo/inspector/KotlinListsTest.kt
@@ -1,0 +1,87 @@
+package app.avo.inspector
+
+import android.app.Application
+import android.content.ContentResolver
+import android.content.SharedPreferences
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import app.avo.inspector.AvoEventSchemaType.AvoList
+import app.avo.inspector.AvoEventSchemaType.AvoNull
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Before
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import java.util.*
+
+class KotlinListsTest {
+
+    lateinit var sut: AvoInspector
+
+    @Mock
+    lateinit var mockApplication: Application
+
+    @Mock
+    lateinit var mockPackageManager: PackageManager
+
+    @Mock
+    lateinit var mockPackageInfo: PackageInfo
+
+    @Mock
+    lateinit var mockApplicationInfo: ApplicationInfo
+
+    @Mock
+    lateinit var mockSharedPrefs: SharedPreferences
+
+    @Mock
+    lateinit var mockEditor: SharedPreferences.Editor
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        Mockito.`when`(mockApplication.packageManager).thenReturn(mockPackageManager)
+        Mockito.`when`(mockApplication.packageName).thenReturn("")
+        Mockito.`when`(mockPackageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(mockPackageInfo)
+        Mockito.`when`(mockApplication.applicationInfo).thenReturn(mockApplicationInfo)
+        Mockito.`when`(mockApplication.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(mockSharedPrefs)
+        Mockito.`when`(mockSharedPrefs.getString(ArgumentMatchers.anyString(), ArgumentMatchers.eq<Any?>(null) as String?)).thenReturn("")
+        Mockito.`when`(mockSharedPrefs.edit()).thenReturn(mockEditor)
+        Mockito.`when`(mockEditor.putLong(ArgumentMatchers.anyString(), ArgumentMatchers.anyLong())).thenReturn(mockEditor)
+        Mockito.`when`(mockEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(mockEditor)
+        Mockito.`when`(mockApplication.applicationContext).thenReturn(mockApplication)
+        Mockito.`when`(mockApplication.contentResolver).thenReturn(Mockito.mock(ContentResolver::class.java))
+
+        sut = AvoInspector("api key", mockApplication, AvoInspectorEnv.Dev)
+    }
+
+    @org.junit.Test
+    fun canExtractJSONArrayOfOptionalLists() {
+        val testJsonObj = JSONObject()
+        try {
+            val items: MutableList<List<*>?> = mutableListOf()
+            testJsonObj.put("list_key", items)
+            val nonOptionalList = listOf(1)
+            val optionalList: List<Int>? = listOf(1)
+
+            items.add(nonOptionalList)
+            items.add(optionalList)
+
+        } catch (e: JSONException) {
+            e.printStackTrace()
+        }
+        val schema: Map<String, AvoEventSchemaType> = sut.extractSchema(testJsonObj)
+        Assert.assertEquals(testJsonObj.length().toLong(), schema.size.toLong())
+        for (key in schema.keys) {
+            val value = schema[key]
+            val expected = AvoList(HashSet())
+            expected.subtypes.add(AvoList(HashSet()))
+            expected.subtypes.add(AvoNull())
+            Assert.assertEquals(expected, value)
+        }
+    }
+}


### PR DESCRIPTION
Got some div by zero errors in Sentry and turns out it can happen if you manually set batch size to 0.