### PR TITLE
fix: mitigate ReDoS vulnerability with RE2

### DIFF
--- a/avoinspector/build.gradle
+++ b/avoinspector/build.gradle
@@ -90,6 +90,7 @@ def analyticsDebuggerDep = isJitPackBuild
 
 dependencies {
     implementation 'androidx.annotation:annotation-jvm:1.8.2'
+    implementation 'com.google.re2j:re2j:1.7'
     developmentApi analyticsDebuggerDep
 
     testImplementation 'junit:junit:4.13.2'

--- a/avoinspector/src/main/java/app/avo/inspector/EventValidator.java
+++ b/avoinspector/src/main/java/app/avo/inspector/EventValidator.java
@@ -7,8 +7,8 @@ import org.json.JSONObject;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import com.google.re2j.Pattern;
+import com.google.re2j.PatternSyntaxException;
 
 /**
  * EventValidator - Client-side validation of tracking events against the Avo Tracking Plan.

--- a/avoinspector/src/test/java/app/avo/inspector/EventValidatorTests.java
+++ b/avoinspector/src/test/java/app/avo/inspector/EventValidatorTests.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.util.*;
 
+import com.google.re2j.PatternSyntaxException;
+
 import static org.junit.Assert.*;
 
 public class EventValidatorTests {
@@ -1242,5 +1244,60 @@ public class EventValidatorTests {
         assertEquals("name", prop.optString("propertyName"));
         // Property should NOT have children since the schema property is a primitive
         assertFalse(prop.has("children"));
+    }
+
+    // =========================================================================
+    // REDOS SAFETY TESTS
+    // =========================================================================
+
+    @Test
+    public void redosPatternCompletesQuicklyWithRe2j() {
+        // (a+)+$ is a classic ReDoS pattern that causes catastrophic backtracking
+        // in java.util.regex but is safe with RE2
+        String redosPattern = "(a+)+$";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 20000; i++) {
+            sb.append('a');
+        }
+        sb.append('!');
+        String evilInput = sb.toString();
+
+        Map<String, PropertyConstraints> props = new HashMap<>();
+        props.put("field", createRegexConstraints(singleMapping(redosPattern, "evt_1")));
+        EventSpecEntry entry = createEntry("evt_1", Collections.emptyList(), props);
+        EventSpecResponse spec = createSpec(Collections.singletonList(entry));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("field", evilInput);
+
+        long start = System.currentTimeMillis();
+        ValidationResult result = EventValidator.validateEvent(properties, spec);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertNotNull(result);
+        // RE2 should complete in well under 1 second; java.util.regex would hang
+        assertTrue("ReDoS pattern took " + elapsed + "ms, expected < 1000ms", elapsed < 1000);
+    }
+
+    @Test
+    public void unsupportedLookaheadPatternHandledGracefully() {
+        // RE2 does not support lookaheads; this should be caught as PatternSyntaxException
+        // and handled gracefully (no crash, no failure for that constraint)
+        String lookaheadPattern = "(?=.*[A-Z]).*";
+
+        Map<String, PropertyConstraints> props = new HashMap<>();
+        props.put("field", createRegexConstraints(singleMapping(lookaheadPattern, "evt_1")));
+        EventSpecEntry entry = createEntry("evt_1", Collections.emptyList(), props);
+        EventSpecResponse spec = createSpec(Collections.singletonList(entry));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("field", "Hello");
+
+        // Should not throw — the PatternSyntaxException is caught in checkRegexPatterns
+        ValidationResult result = EventValidator.validateEvent(properties, spec);
+        assertNotNull(result);
+        // The invalid pattern is skipped, so no eventIds are failed by it
+        PropertyValidationResult pvr = result.propertyResults.get("field");
+        assertNull(pvr.failedEventIds);
     }
 }

--- a/avoinspector/src/test/java/app/avo/inspector/EventValidatorTests.java
+++ b/avoinspector/src/test/java/app/avo/inspector/EventValidatorTests.java
@@ -1250,7 +1250,7 @@ public class EventValidatorTests {
     // REDOS SAFETY TESTS
     // =========================================================================
 
-    @Test
+    @Test(timeout = 1000)
     public void redosPatternCompletesQuicklyWithRe2j() {
         // (a+)+$ is a classic ReDoS pattern that causes catastrophic backtracking
         // in java.util.regex but is safe with RE2
@@ -1270,13 +1270,13 @@ public class EventValidatorTests {
         Map<String, Object> properties = new HashMap<>();
         properties.put("field", evilInput);
 
-        long start = System.currentTimeMillis();
+        long startNanos = System.nanoTime();
         ValidationResult result = EventValidator.validateEvent(properties, spec);
-        long elapsed = System.currentTimeMillis() - start;
+        long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
 
         assertNotNull(result);
         // RE2 should complete in well under 1 second; java.util.regex would hang
-        assertTrue("ReDoS pattern took " + elapsed + "ms, expected < 1000ms", elapsed < 1000);
+        assertTrue("ReDoS pattern took " + elapsedMillis + "ms, expected < 1000ms", elapsedMillis < 1000);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace backtracking `java.util.regex` with linear-time `com.google.re2j` in EventValidator
- Drop-in replacement: `Pattern.compile()`, `.matcher().find()`, and `PatternSyntaxException` all work identically
- Patterns unsupported by RE2 (e.g. lookaheads) are caught by the existing `PatternSyntaxException` handler

## Why

Regex patterns from `EventSpecResponse` are compiled with `Pattern.compile()`. A malicious or compromised pattern like `(a+)+$` matched against a long string causes exponential CPU usage (ReDoS). RE2 guarantees linear-time matching.

## Changes

| File | Change |
|------|--------|
| `build.gradle` | Add `com.google.re2j:re2j:1.7` dependency |
| `EventValidator.java` | Swap 2 import lines (`java.util.regex` → `com.google.re2j`) |
| `EventValidatorTests.java` | Add ReDoS safety test + unsupported pattern test |

## Test plan

- [x] ReDoS pattern `(a+)+$` with 20,000 chars completes < 1 second
- [x] Lookahead pattern handled gracefully (PatternSyntaxException caught)
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced regex processing for improved event validation reliability.

* **Tests**
  * Added tests for regex pattern handling and edge case scenarios to ensure robust event validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->